### PR TITLE
fix: avoid to pass to openssl the same file as input and output

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -623,7 +623,9 @@ sign_domain() {
   cat "${crt_path}" > "${CERTDIR}/${domain}/fullchain-${timestamp}.pem"
   http_request get "$(openssl x509 -in "${CERTDIR}/${domain}/cert-${timestamp}.pem" -noout -text | grep 'CA Issuers - URI:' | cut -d':' -f2-)" > "${CERTDIR}/${domain}/chain-${timestamp}.pem"
   if ! grep -q "BEGIN CERTIFICATE" "${CERTDIR}/${domain}/chain-${timestamp}.pem"; then
-    openssl x509 -in "${CERTDIR}/${domain}/chain-${timestamp}.pem" -inform DER -out "${CERTDIR}/${domain}/chain-${timestamp}.pem" -outform PEM
+    openssl x509 -in "${CERTDIR}/${domain}/chain-${timestamp}.pem" -inform DER -out "${CERTDIR}/${domain}/chain-temp-${timestamp}.pem" -outform PEM
+    rm "${CERTDIR}/${domain}/chain-${timestamp}.pem"
+    mv "${CERTDIR}/${domain}/chain-temp-${timestamp}.pem" "${CERTDIR}/${domain}/chain-${timestamp}.pem"
   fi
   cat "${CERTDIR}/${domain}/chain-${timestamp}.pem" >> "${CERTDIR}/${domain}/fullchain-${timestamp}.pem"
 


### PR DESCRIPTION
This fixes an issue in running `letsencrypt` when `OpenSSL 1.1.0g` is available. 
Currently we are using this in `Ubuntu 14.04`, which has `OpenSSL 1.0.1f 6 Jan 2014` installed. 

Apparently if the input and output of the `openssl` command is the same file, the command fails. 
I didn't find a bug report for this, but it's actually something pretty logical, if -for instance- openssl doesn't load all the input file upfront.

Writing to a temp file then renaming fixed this. 
Tested launching `lestencrypt.sh` manually on new `delphi.staging` with `Ubuntu 18.04` and `OpenSSL 1.1.0g`